### PR TITLE
GNOME based desktops use get_monitor_geometry for screen dimensions

### DIFF
--- a/lib/PositionManager.vala
+++ b/lib/PositionManager.vala
@@ -65,8 +65,14 @@ namespace Plank
 			screen.composited_changed.connect (screen_composited_changed);
 			
 			// NOTE don't call update_monitor_geo to avoid a double-call of dockwindow.set_size on startup
-			monitor_geo = screen.get_monitor_workarea (find_monitor_number (screen, controller.prefs.Monitor));
-			
+			var session=Environment.get_variable("XDG_CURRENT_DESKTOP");
+			if (session != null && session.contains("GNOME")) {
+				screen.get_monitor_geometry (find_monitor_number (screen, controller.prefs.Monitor), out monitor_geo);
+			}
+			else {
+				monitor_geo = screen.get_monitor_workarea (find_monitor_number (screen, controller.prefs.Monitor));
+			};
+
 			screen_is_composited = screen.is_composited ();
 		}
 		
@@ -133,9 +139,15 @@ namespace Plank
 		void screen_changed (Gdk.Screen screen)
 		{
 			var old_monitor_geo = monitor_geo;
-			
-			var monitor_geo = screen.get_monitor_workarea (find_monitor_number (screen, controller.prefs.Monitor));
-			
+
+			var session=Environment.get_variable("XDG_CURRENT_DESKTOP");
+			if (session != null && session.contains("GNOME")) {
+				screen.get_monitor_geometry (find_monitor_number (screen, controller.prefs.Monitor), out monitor_geo);
+			}
+			else {
+				monitor_geo = screen.get_monitor_workarea (find_monitor_number (screen, controller.prefs.Monitor));
+			};
+
 			// No need to do anything if nothing has actually changed
 			if (old_monitor_geo.x == monitor_geo.x
 				&& old_monitor_geo.y == monitor_geo.y


### PR DESCRIPTION
Hi there,

 if possible will you consider adding this PR to your original plank PR - this will ensure GNOME based desktops use the original code method in plank rather than the revised workspace area method which i think your XFCE (?) based PR uses.

At the moment distros such as debian and ubuntu have pulled in your PR - but this unfortunately breaks Ubuntu-Xorg (GNOME-Shell), Debian GNOME Shell and Ubuntu with the Budgie Desktop.